### PR TITLE
Prefill selected date when scheduling a new class

### DIFF
--- a/src/components/tutor/TutorScheduler.tsx
+++ b/src/components/tutor/TutorScheduler.tsx
@@ -80,15 +80,20 @@ const TutorScheduler: React.FC = () => {
     }
   }, [user?.id, newEvent, setNewEvent, currentUser]);
 
+  const handleAddEventClick = () => {
+    setNewEvent((prev) => ({ ...prev, date: selectedDate }));
+    setIsAddEventOpen(true);
+  };
+
   // Display loading state while data is being fetched
   if (isLoading) {
     return (
       <div className="space-y-4 sm:space-y-6">
-        <TutorSchedulerHeader onAddClick={() => setIsAddEventOpen(true)} />
+        <TutorSchedulerHeader onAddClick={handleAddEventClick} />
         <div className="overflow-x-auto">
-          <TableSkeleton 
-            columns={['Date', 'Time', 'Student', 'Subject', 'Actions']} 
-            rowCount={5} 
+          <TableSkeleton
+            columns={['Date', 'Time', 'Student', 'Subject', 'Actions']}
+            rowCount={5}
             cellWidths={['w-24', 'w-32', 'w-40', 'w-32', 'w-24']} 
           />
         </div>
@@ -98,7 +103,7 @@ const TutorScheduler: React.FC = () => {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      <TutorSchedulerHeader onAddClick={() => setIsAddEventOpen(true)} />
+      <TutorSchedulerHeader onAddClick={handleAddEventClick} />
       
       <TutorSchedulerFilters
         searchTerm={searchTerm}
@@ -116,7 +121,7 @@ const TutorScheduler: React.FC = () => {
           setSelectedDate={setSelectedDate}
           scheduledClasses={filteredClasses}
           onSelectEvent={handleSelectEvent}
-          onAddEventClick={() => setIsAddEventOpen(true)}
+          onAddEventClick={handleAddEventClick}
           getUnreadMessageCount={getUnreadMessageCount}
         />
       </div>

--- a/src/components/tutor/dialogs/AddClassDialog.tsx
+++ b/src/components/tutor/dialogs/AddClassDialog.tsx
@@ -53,17 +53,20 @@ const AddClassDialog: React.FC<AddClassDialogProps> = ({
       ? `${currentUser.first_name} ${currentUser.last_name || ''}`.trim() 
       : 'Current Tutor';
       
-    setNewEvent((prev: any) => ({
-      ...prev,
-      tutorId: tutorId,
-      tutorName: tutorDisplayName,
-      date: nextHour,
-      startTime: format(nextHour, 'HH:mm'),
-      endTime: format(addHours(nextHour, 1), 'HH:mm'),
-      title: 'New Class Session',
-      subject: '',
-      zoomLink: 'https://zoom.us/',
-    }));
+    setNewEvent((prev: any) => {
+      const baseDate = prev.date || nextHour;
+      return {
+        ...prev,
+        tutorId: tutorId,
+        tutorName: tutorDisplayName,
+        date: baseDate,
+        startTime: prev.startTime || format(nextHour, 'HH:mm'),
+        endTime: prev.endTime || format(addHours(nextHour, 1), 'HH:mm'),
+        title: prev.title || 'New Class Session',
+        subject: prev.subject || '',
+        zoomLink: prev.zoomLink || 'https://zoom.us/',
+      };
+    });
     
     // Load relationships and students data
     const loadRelationshipsAndStudents = async () => {


### PR DESCRIPTION
## Summary
- Ensure scheduler uses selected calendar date when opening the add class form
- Respect existing form values so chosen date persists when dialog opens

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e0aca848483239ccdff4499c087e2